### PR TITLE
Add rate_limit metadata to client on each request

### DIFF
--- a/grackle.gemspec
+++ b/grackle.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Hayes Davis"]
-  s.date = %q{2010-6-13}
+  s.date = %q{2010-06-13}
   s.description = %q{Grackle is a lightweight library for the Twitter REST and Search API.}
   s.email = %q{hayes@appozite.com}
   s.files = ["CHANGELOG.rdoc", "README.rdoc", "grackle.gemspec", "lib/grackle.rb", "lib/grackle/client.rb", "lib/grackle/handlers.rb", "lib/grackle/transport.rb", "lib/grackle/utils.rb", "test/test_grackle.rb", "test/test_helper.rb", "test/test_client.rb", "test/test_handlers.rb"]

--- a/lib/grackle/client.rb
+++ b/lib/grackle/client.rb
@@ -98,7 +98,7 @@ module Grackle
     }
     
     attr_accessor :auth, :handlers, :default_format, :headers, :ssl, :api, 
-      :transport, :request, :api_hosts, :timeout, :auto_append_ids
+      :transport, :request, :api_hosts, :timeout, :auto_append_ids, :rate_limit
     
     # Arguments (all are optional):
     # - :username       - twitter username to authenticate with (deprecated in favor of :auth arg)
@@ -247,6 +247,7 @@ module Grackle
           unless res.status == 200
             handle_error_response(res,fmt_handler)
           else
+            self.rate_limit = res.rate_limit
             fmt_handler.decode_response(res.body)
           end
         rescue TwitterError => e


### PR DESCRIPTION
after each request, `client.rate_limit` contains a hash representing the available rate limit information, pulled from the headers.
