### PR TITLE
Add API v1.1 support

### DIFF
--- a/lib/grackle/client.rb
+++ b/lib/grackle/client.rb
@@ -87,16 +87,23 @@ module Grackle
     # refer to it wherever Grackle::Client uses an API symbol. You may wish 
     # to do this when Twitter introduces API versions greater than 1.
     TWITTER_API_HOSTS = {
-      :search=>'search.twitter.com', :v1=>'api.twitter.com/1',
+      :v1=>'api.twitter.com/1',
+      :v1_1=>'api.twitter.com/1.1',
+      :search=>'search.twitter.com',
       :upload=>'upload.twitter.com/1'
     }
     TWITTER_API_HOSTS[:rest] = TWITTER_API_HOSTS[:v1]
 
     # Contains the response headers from twitter
-    DEFAULT_RESPONSE_HEADERS =[
-      'x-ratelimit-limit',
-      'x-ratelimit-remaining',
-      'x-ratelimit-reset'
+    DEFAULT_RESPONSE_HEADERS = Hash.new(%w[
+      x-ratelimit-limit
+      x-ratelimit-remaining
+      x-ratelimit-reset
+    ])
+    DEFAULT_RESPONSE_HEADERS[:v1_1] = %w[
+      x-rate-limit-limit
+      x-rate-limit-remaining
+      x-rate-limit-reset
     ]
 
     #Basic OAuth information needed to communicate with Twitter
@@ -137,7 +144,7 @@ module Grackle
       self.timeout = options[:timeout] || 60
       self.auto_append_ids = options[:auto_append_ids] == false ? false : true
       self.auth = {}
-      self.response_headers = options[:response_headers] || DEFAULT_RESPONSE_HEADERS.clone
+      self.response_headers = options[:response_headers] || DEFAULT_RESPONSE_HEADERS[self.api].clone
       self.valid_http_codes = options[:valid_http_codes] || VALID_HTTP_CODES.clone
       if options.has_key?(:username) || options.has_key?(:password)
         #Use basic auth if :username and :password args are passed in

--- a/lib/grackle/version.rb
+++ b/lib/grackle/version.rb
@@ -1,6 +1,6 @@
 module Grackle
 
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 
   def self.version
     VERSION

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -202,16 +202,16 @@ class ClientTest < Test::Unit::TestCase
     client = new_client(200, '[{"id":1,"text":"test 1"}]')
 
     # Load up some other headers in the response
-    Grackle::Client::DEFAULT_RESPONSE_HEADERS.each_with_index do |header,i|
+    Grackle::Client::DEFAULT_RESPONSE_HEADERS[:v1].each_with_index do |header,i|
       Net::HTTP.response[header] = "value#{i}"
     end
 
     client.statuses.public_timeline?
     headers = client.response.headers
     assert(!headers.nil?)
-    assert_equal(Grackle::Client::DEFAULT_RESPONSE_HEADERS.size, headers.size)
+    assert_equal(Grackle::Client::DEFAULT_RESPONSE_HEADERS[:v1].size, headers.size)
 
-    Grackle::Client::DEFAULT_RESPONSE_HEADERS.each_with_index do |h,i|
+    Grackle::Client::DEFAULT_RESPONSE_HEADERS[:v1].each_with_index do |h,i|
       assert_equal("value#{i}",headers[h])
     end
   end
@@ -392,6 +392,17 @@ class ClientTest < Test::Unit::TestCase
     assert_nothing_raised do
       value = client.users.show.json? :screen_name=>'test_user'
     end
+  end
+
+  def test_v1_1_endpoint
+    client = new_client(200,'{}',:api=>:v1_1)
+    client.users.show.hayesdavis?
+    assert_equal('/1.1/users/show/hayesdavis.json',client.transport.url.path,"API v1.1 should have the right path")
+  end
+
+  def test_v1_1_default_response_headers
+    client = new_client(200,'{}',:api=>:v1_1)
+    assert_equal(%w[x-rate-limit-limit x-rate-limit-remaining x-rate-limit-reset],client.response_headers)
   end
 
   private


### PR DESCRIPTION
Support v1.1 of Twitter's API. This includes adding a new endpoint,
updating the rate limit headers, and bumping the version number.

Tests have also been updated.

Note that there are no checks to make sure you're using OAuth and JSON
with v1.1, so you can shoot yourself in the foot by using v1.1 with
basic auth or a non-JSON format if you want.
