### PR TITLE
Use stderr instead of stdout, allow silencing the message

### DIFF
--- a/lib/grackle/transport.rb
+++ b/lib/grackle/transport.rb
@@ -58,6 +58,7 @@ module Grackle
     
     class << self
       attr_accessor :ca_cert_file
+      attr_accessor :be_wildly_insecure
     end
     
     def req_class(method)
@@ -267,7 +268,7 @@ module Grackle
           # Turn off SSL verification which gets rid of warning in 1.8.x and 
           # an error in 1.9.x.
           conn.verify_mode = OpenSSL::SSL::VERIFY_NONE
-          unless @ssl_warning_shown
+          unless @ssl_warning_shown || self.class.be_wildly_insecure
             $stderr.puts <<-EOS
 Warning: SSL Verification is not being performed. While your communication is 
 being encrypted, the identity of the other party is not being confirmed nor the 

--- a/lib/grackle/transport.rb
+++ b/lib/grackle/transport.rb
@@ -268,7 +268,7 @@ module Grackle
           # an error in 1.9.x.
           conn.verify_mode = OpenSSL::SSL::VERIFY_NONE
           unless @ssl_warning_shown
-            puts <<-EOS
+            $stderr.puts <<-EOS
 Warning: SSL Verification is not being performed. While your communication is 
 being encrypted, the identity of the other party is not being confirmed nor the 
 SSL certificate verified. It's recommended that you specify a file containing 


### PR DESCRIPTION
For scripts that pipe their output, it's better to put warnings like the "Download a cacerts.pem" into standard error instead of standard output, especially if they come from a library.

The second commit is slightly more speculative.  It allows silencing the message by setting Grackle::Transport.be_wildly_insecure which, hopefully, is a scary enough name to ensure that it won't be carelessly used.  (It certainly beats, e.g., overriding initialize in the client to set @ssl_warning_shown or creative use of IO.dup().)
